### PR TITLE
[ENG-1479] chore(deps): update vercel project terraform module version 1.4.2 => 1.6.0

### DIFF
--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -12,7 +12,7 @@ resource "terraform_data" "workspace_validation" {
 }
 
 module "vercel" {
-  source                           = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.4.2"
+  source                           = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.6.0"
   build_type                       = "website"
   cloudflare_zone_domain           = var.cloudflare_zone_domain
   framework                        = "other"


### PR DESCRIPTION
- v1.6.0 sets the default region for vercel serverless functions to London (from US east)