### PR TITLE
chore: add cloud-ops dependabot and codeowners config [ENG-1499]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Tag cloud-ops for any terraform changes
+infrastructure/ @oaknational/cloud-ops
+
+# Tag cloud-ops for any changes to terraform workflows
+.github/workflows/terraform_*.yml @oaknational/cloud-ops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Track updates for Github Actions workflows from oak-terraform-actions repository.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    allow:
+      - dependency-name: "oaknational/oak-terraform-actions"
+      - dependency-name: "oaknational/oak-release-actions"
+    schedule:
+      interval: "daily"
+
+  # Track updates for Terraform modules from oak-terraform-modules repository.
+  - package-ecosystem: "terraform"
+    directories: ["infrastructure/**/*"]
+    allow:
+      - dependency-name: "*::github::oaknational/oak-terraform-modules::*"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- use dependabot to update terraform module and terraform related github action versions
- use codeowners to tag cloud-ops in the reulting PRs